### PR TITLE
Fix layout overflow in CurrentServiceFragment

### DIFF
--- a/app/src/main/res/layout/fragment_current_service.xml
+++ b/app/src/main/res/layout/fragment_current_service.xml
@@ -1,17 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/textNavigation"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fillViewport="true"
     tools:context=".ui.service.current.CurrentServiceFragment">
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/toggle_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/toggle_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:clickable="true"
@@ -22,10 +26,10 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/connected_service_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/connected_service_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:clickable="true"
@@ -323,3 +327,5 @@
         app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
## Summary
- wrap the CurrentServiceFragment layout in a `NestedScrollView`
- adjust child layout to enable scrolling when fonts are large

## Testing
- `./gradlew test` *(fails: The file '/workspace/gorda-driver/local.properties' could not be found)*
- `./gradlew assembleDebug` *(fails: The file '/workspace/gorda-driver/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_688952e37e7c8324852ff0f1818be2cd