### PR TITLE
Fix CurrentServiceFragment layout for accessibility

### DIFF
--- a/app/src/main/res/layout/fragment_current_service.xml
+++ b/app/src/main/res/layout/fragment_current_service.xml
@@ -36,17 +36,21 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layoutFees"
-        android:layout_width="match_parent"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/current_service_scroll"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        android:visibility="invisible"
-        app:layout_constraintBottom_toTopOf="@+id/service_layout"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@id/toggle_button"
+        app:layout_constraintBottom_toTopOf="@id/service_layout"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="1.0">
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layoutFees"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="invisible">
 
         <TextView
             android:id="@+id/textPrice"
@@ -313,13 +317,12 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <include
-        android:id="@+id/service_layout"
-        layout="@layout/service_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+            <include
+                android:id="@+id/service_layout"
+                layout="@layout/service_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+    </androidx.core.widget.NestedScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- make fees portion scroll independently so larger fonts don't clip

## Testing
- `./gradlew test` *(fails: local.properties not found)*

------
https://chatgpt.com/codex/tasks/task_e_688952e37e7c8324852ff0f1818be2cd